### PR TITLE
updating modules.json with meanjs MVC project

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -11,6 +11,7 @@
 	, "matador": "obvious/matador"
 	, "partial.js": "petersirka/partial.js"
 	, "sails": "balderdashy/sails"
+	, "meanjs": "meanjs/mean"
 	, "socketstream": "socketstream/socketstream"
 	, "spludo": "DracoBlue/spludo"
 	, "strata": "mjijackson/strata"


### PR DESCRIPTION
Adding the MEAN.JS MVC project (meanjs.org) to the list.
Notice that the repository name for meanjs is the same for the meanio projects (they both use 'mean' as the repository name) - how about we update the file naming convention of the images to add as screenshots to public/images folder to handle that?